### PR TITLE
Patch/minor tweaks and java loader

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -63,6 +63,19 @@ component {
 
 	/**
 	 * --------------------------------------------------------------------------
+	 * Manually load JDBC jar as an OSGI bundle
+	 * --------------------------------------------------------------------------
+	 */
+	bundleSymbolicName = "org.sqlite.JDBC";
+	bundleVersion = "3.40.0";
+	bundlePath = ExpandPath( "/lib/java/sqlite-jdbc-3.40.0.0.jar" );
+	osgiLoader = new models.util.OSGILoader();
+	if( !osgiLoader.bundleIsLoaded( bundleSymbolicName, bundleVersion ) ){
+		osgiLoader.installBundle( bundlePath );
+	}
+
+	/**
+	 * --------------------------------------------------------------------------
 	 * ORM + Datasource Settings
 	 * --------------------------------------------------------------------------
 	 */

--- a/models/util/OSGILoader.cfc
+++ b/models/util/OSGILoader.cfc
@@ -1,0 +1,49 @@
+/**
+ * Install, uninstall, and manage OSGI bundles.
+ * 
+ * @author cfsimplicity - https://github.com/cfsimplicity
+ * @cite https://github.com/cfsimplicity/luceeOsgiLoader
+ */
+component accessors="true"{
+
+	/*
+		I encapsulate methods for loading OSGi bundles dynamically
+	*/
+
+	property name="CFMLEngineFactory";
+	property name="luceeOSGiUtil";
+	property name="version" default="1.0.0" setter="false";
+
+	public any function init(){
+		variables.luceeOSGiUtil = CreateObject( "java", "lucee.runtime.osgi.OSGiUtil" );
+		variables.CFMLEngineFactory = CreateObject( "java", "lucee.loader.engine.CFMLEngineFactory" ).getInstance();
+		return this;
+	}
+
+	public any function loadClass( required string className, required string bundlePath, required string bundleSymbolicName, required string bundleVersion ){
+		if( !bundleIsLoaded( arguments.bundleSymbolicName, arguments.bundleVersion ) ) installBundle( arguments.bundlePath );
+		return CreateObject( "java", arguments.className, arguments.bundleSymbolicName, arguments.bundleVersion );
+	}
+
+	public void function installBundle( required string path ){
+		var CFMLEngineFactory = this.getCFMLEngineFactory();
+		var resource = CFMLEngineFactory.getResourceUtil().toResourceExisting( GetPageContext(), JavaCast( "string", arguments.path ) );
+		this.getLuceeOSGiUtil().installBundle( CFMLEngineFactory.getBundleContext(), resource, JavaCast( "boolean", true ) );
+	}
+
+	public void function uninstallBundle( required string bundleSymbolicName, required string bundleVersion ){
+		var bundle = getBundle( arguments.bundleSymbolicName, arguments.bundleVersion );
+		if( IsNull( bundle ) ) return;
+		bundle.uninstall();
+	}
+
+	public any function getBundle( required string bundleSymbolicName, required string bundleVersion ){
+		var OSGiUtil = this.getLuceeOSGiUtil();
+		return OSGiUtil.getBundleLoaded( arguments.bundleSymbolicName, OSGiUtil.toVersion( arguments.bundleVersion ), JavaCast( "null", "" ) );
+	}
+
+	public boolean function bundleIsLoaded( required string bundleSymbolicName, required string bundleVersion ){
+		return !IsNull( getBundle( arguments.bundleSymbolicName, arguments.bundleVersion ) );
+	}
+
+}

--- a/server.json
+++ b/server.json
@@ -1,9 +1,13 @@
 {
     "app":{
+        "cfengine":"lucee@5.4.3.2",
         "libDirs":"lib/java"
     },
     "open":true,
     "web":{
+        "http":{
+            "port":"46347"
+        },
         "rewrites":{
             "enable":"true"
         }


### PR DESCRIPTION
* Set web.http.port and lucee server version so each `server start` is consistent
* Use [CFSimplicity's OSGILoader](https://github.com/cfsimplicity/luceeOsgiLoader) for reliable .jar file installations.